### PR TITLE
Adding debian package build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ It doesn't released in any repository yet, for try it you may use archlinux pkgb
 - [x] Send maintainer to therapy ( Done by sohrab and HUSS )
 - [x] publish in parch repos ( Done by sohrab )
 - [ ] publish in AUR
-- [ ] Add build file for debian
+- [X] Add build file for debian
 - [ ] Add build file for redhat

--- a/package/debian/build.sh
+++ b/package/debian/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+
+pkgname="namban"
+pkgver="0.2"
+arch="amd64"
+maintainer="meshya, D3F4U1T"
+pkgdesc="A simple gui tool for set dns settings."
+pkgdir="$(pwd)"/"$pkgname"_"$pkgver"_"$arch"
+srcdir="$(pwd)/namban"
+
+# TODO: Add the dependencies
+# TODO: Create a CI/CD workflow to auto build the package
+
+prepare() {
+	git clone -b "v$pkgver" --depth=1 "https://github.com/parchlinuxB/namban"
+}
+
+package() {
+	mkdir -p "$pkgdir/"{DEBIAN,'usr/'}
+	cp -r "$srcdir/package/files/rootfs/"{usr,etc} "$pkgdir/"
+	cp -r "$srcdir/src/" "$pkgdir/usr/lib/namban/src/"
+
+	echo "Package: $pkgname
+	Version: $pkgver
+	Architecture: $arch
+	Maintainer: $maintainer
+	Description: $pkgdesc" | tr -d '\t' > "$pkgdir/DEBIAN/control"
+
+	chmod +x "$pkgdir/usr/"{bin/namban,lib/namban/{nambanbin,namban-startup-check}}
+
+	dpkg-deb --build --root-owner-group "$pkgdir"
+}
+
+cleanup() {
+	rm -rf "$pkgdir"
+	rm -rf "$srcdir"
+}
+
+prepare
+package
+cleanup


### PR DESCRIPTION
- Note: It works on Arch Linux but make sure to install dpkg package to build it.

- TODO: Need to add dependencies and create a CI/CD
  -  We can use distrobox to test it in a containerized environment and detect
  the dependencies needed.
  - Also we can use github actions to create a CI/CD to automatically build
  and release the packages.