### PR TITLE
Adding debian package build workflow + version bump

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -1,0 +1,32 @@
+name: package namban for debian
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    container:
+      image: debian:12
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install gh-cli
+        run: |
+          apt update
+          apt install gh
+
+      - name: Run the build script
+        run: ./package/debian/build.sh
+
+      - name: Upload the package file to the release
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ./namban*.deb -R ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It doesn't released in any repository yet, for try it you may use archlinux pkgb
 - [x] publish in parch repos ( Done by sohrab )
 - [ ] publish in AUR
 - [X] Add build file for debian ( Done by ARS101 )
-- [ ] Create a CI/CD 4 debian
+- [X] Create a CI/CD 4 debian ( Done by ARS101 )
 - [ ] Add build file for redhat
 - [ ] Error Message for wrong input [#5](https://github.com/parchlinuxB/namban/issues/5)
 ## Far To Do

--- a/package/debian/build.sh
+++ b/package/debian/build.sh
@@ -2,7 +2,7 @@
 
 
 pkgname="namban"
-pkgver="0.2"
+pkgver="0.3-1"
 arch="amd64"
 maintainer="meshya, D3F4U1T"
 pkgdesc="A simple gui tool for set dns settings."


### PR DESCRIPTION
Added the workflow to automatically build a debian package for each release.

Make sure to bump the build script version to make the correct version of the package.
A fix is underway, so this pull request can be on hold till the fix arrives.